### PR TITLE
fluidlogged-api compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ Pulsar fully replaces the vanilla lighting engine, so it conflicts with anything
 
 ### Not recommended
 
-- **OptiFine** — untested, most likely incompatible. Use [Celeritas](https://github.com/kappa-maintainer/Celeritas-auto-build) instead (see below).
+- **OptiFine** — untested, most likely incompatible. Use [Nothirium](https://github.com/Meldexun/Nothirium) or [Celeritas](https://github.com/kappa-maintainer/Celeritas-auto-build) instead (see below).
 
 ### Works with
 
+- **[Nothirium](https://github.com/Meldexun/Nothirium)** (+ RenderLib; on Cleanroom add [Naughthirium](https://www.curseforge.com/minecraft/mc-mods/naughthirium)) — verified in-game. No dedicated hooks needed: Nothirium reads light lazily from live chunk data at mesh time, so Pulsar's light updates flow through the standard render-update path. You will see one benign mixin-overlap warning at startup — both mods apply the identical `getPackedLightmapCoords` fix, so whichever wins, behaviour is the same.
 - **[Celeritas](https://github.com/kappa-maintainer/Celeritas-auto-build)** — Pulsar ships two optional integrations, both **off by default** while their FPS impact during chunk streaming is being measured (see Trade-offs): `compat.celeritasDirectionalMeshLight` routes Celeritas's chunk-meshing light lookups through the MC-92 directional fix (restart required), and `compat.celeritasCloneInvalidation` invalidates Celeritas's cloned-section cache on light changes so meshes never rebuild from stale light — enable it if you see lighting stick in sealed rooms. Both are soft hooks that disable themselves cleanly when Celeritas is absent.
 - So far, it works without conflicting with the mods I regularly use, such as Chibi, Universal Tweaks, StellarCore, and VintageFix.
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -22,6 +22,9 @@ dependencies {
     // mixinbooter: required for IEarlyMixinLoader (PulsarLoadingPlugin uses it).
     // Cleanroom bundles a runtime version, but we still need the API at compile time.
     compileOnly "zone.rong:mixinbooter:10.5"
+    // Fluidlogged API: soft dependency — FluidLightBridge merges the stored
+    // fluid's opacity/emission into the engine's light reads when installed.
+    compileOnly "maven.modrinth:fluidlogged-api:3.3.3"
     if (enable_lwjglx.toBoolean()) {
         compileOnly "com.cleanroommc:lwjglx:1.0.0"
     }

--- a/src/main/java/com/sumirelabs/pulsar/compat/FluidLightBridge.java
+++ b/src/main/java/com/sumirelabs/pulsar/compat/FluidLightBridge.java
@@ -1,0 +1,78 @@
+package com.sumirelabs.pulsar.compat;
+
+import com.sumirelabs.pulsar.light.engine.LightInfo;
+import git.jbredwards.fluidlogged_api.api.capability.IFluidStateCapability;
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Fluidlogged API integration: makes the engine see the fluid stored in a
+ * fluidlogged block. Fluidlogged keeps that fluid in a per-chunk capability
+ * (invisible to per-state caches) and patches the VANILLA engine to use
+ * {@code max(block, fluid)} for opacity and light value — this bridge applies
+ * the identical formula to Pulsar's packed {@link LightInfo} reads, so
+ * results match vanilla-with-Fluidlogged semantics. (Alfheim's merged
+ * integration uses the same max() in its {@code LightUtil}.)
+ *
+ * <p>Classloading: Fluidlogged types are referenced only inside branches
+ * guarded by {@link #LOADED}, so this class is safe to load when the mod is
+ * absent (same pattern Alfheim ships).
+ *
+ * <p>Threading: worker-side reads land on Fluidlogged's plain
+ * {@code FluidState[256]} layers — reference reads are atomic, and any
+ * concurrent fluidlog fires {@code world.checkLight}, which re-schedules the
+ * engine; transient staleness self-heals exactly like live nibble reads.
+ */
+public final class FluidLightBridge {
+
+    public static final boolean LOADED = Loader.isModLoaded("fluidlogged_api");
+
+    private FluidLightBridge() {}
+
+    /** The chunk's fluid capability as an opaque handle, or {@code null}. */
+    public static Object capabilityOf(final Chunk chunk) {
+        if (!LOADED || chunk == null) {
+            return null;
+        }
+        return IFluidStateCapability.get(chunk);
+    }
+
+    /**
+     * Max the fluid's opacity/emission at (x, y, z) into packed
+     * {@link LightInfo} bits. The fluid fills the whole block space, so the
+     * combined cell becomes a plain uniform absorber (face bits dropped) —
+     * the same scalar semantics Fluidlogged patches into vanilla.
+     */
+    public static int merge(final int info, final Object capability, final int x, final int y, final int z) {
+        final FluidState fluid = ((IFluidStateCapability) capability)
+                .getContainer(y).getFluidState(x, y, z, FluidState.EMPTY);
+        if (fluid.isEmpty()) {
+            return info;
+        }
+        final int fluidInfo = LightInfo.of(fluid.getState());
+        final int opacity = Math.max(info & LightInfo.OPACITY_MASK, fluidInfo & LightInfo.OPACITY_MASK);
+        final int emission = Math.max(LightInfo.emission(info), LightInfo.emission(fluidInfo));
+        return LightInfo.COMPUTED | opacity | (emission << LightInfo.EMISSION_SHIFT);
+    }
+
+    /**
+     * Scalar vanilla-range opacity with the fluid layer max'd in — for the
+     * heightmap walks in {@code MixinChunk}, which only need
+     * {@code getLightOpacity()} semantics (0-255) rather than packed info.
+     */
+    public static int maxOpacityAt(final Chunk chunk, final int blockOpacity, final int x, final int y, final int z) {
+        if (!LOADED) {
+            return blockOpacity;
+        }
+        final IFluidStateCapability cap = IFluidStateCapability.get(chunk);
+        if (cap == null) {
+            return blockOpacity;
+        }
+        final FluidState fluid = cap.getContainer(y).getFluidState(x, y, z, FluidState.EMPTY);
+        if (fluid.isEmpty()) {
+            return blockOpacity;
+        }
+        return Math.max(blockOpacity, fluid.getState().getLightOpacity());
+    }
+}

--- a/src/main/java/com/sumirelabs/pulsar/light/engine/PulsarEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/PulsarEngine.java
@@ -3,6 +3,7 @@ package com.sumirelabs.pulsar.light.engine;
 import com.sumirelabs.pulsar.Pulsar;
 import com.sumirelabs.pulsar.api.ExtendedWorld;
 import com.sumirelabs.pulsar.compat.CeleritasCloneCacheBridge;
+import com.sumirelabs.pulsar.compat.FluidLightBridge;
 import com.sumirelabs.pulsar.light.LightStats;
 import com.sumirelabs.pulsar.light.RenderBounds;
 import com.sumirelabs.pulsar.light.SWMRNibbleArray;
@@ -226,6 +227,9 @@ public abstract class PulsarEngine {
                 }
 
                 this.setChunkInCache(cx, cz, chunk);
+                if (FluidLightBridge.LOADED) {
+                    this.fluidCapCache[cx + 5 * cz + this.chunkIndexOffset] = FluidLightBridge.capabilityOf(chunk);
+                }
                 this.setEmptinessMapCache(cx, cz, this.getEmptinessMap(chunk));
                 if (!isTwoRadius) {
                     this.setBlocksForChunkInCache(cx, cz, chunk.getBlockStorageArray());
@@ -241,6 +245,24 @@ public abstract class PulsarEngine {
 
     protected final void setChunkInCache(final int chunkX, final int chunkZ, final Chunk chunk) {
         this.chunkCache[chunkX + 5 * chunkZ + this.chunkIndexOffset] = chunk;
+    }
+
+    /** Fluidlogged-API chunk capabilities, parallel to the chunk cache (all null when the mod is absent). */
+    protected final Object[] fluidCapCache = new Object[5 * 5];
+
+    /**
+     * Packed light info for {@code state} at a world position: the per-state
+     * cache plus — when Fluidlogged API is installed — the fluid stored at
+     * that position max'd in (opacity/emission, uniform faces), mirroring
+     * Fluidlogged's own max() patches on the vanilla engine.
+     */
+    protected final int lightInfoAt(final IBlockState state, final int worldX, final int worldY, final int worldZ) {
+        final int info = LightInfo.of(state);
+        if (!FluidLightBridge.LOADED) {
+            return info;
+        }
+        final Object cap = this.fluidCapCache[(worldX >> 4) + 5 * (worldZ >> 4) + this.chunkIndexOffset];
+        return cap == null ? info : FluidLightBridge.merge(info, cap, worldX, worldY, worldZ);
     }
 
     protected final ExtendedBlockStorage getChunkSection(final int chunkX, final int chunkY, final int chunkZ) {
@@ -328,6 +350,7 @@ public abstract class PulsarEngine {
         Arrays.fill(this.nibbleCache, null);
         Arrays.fill(this.chunkCache, null);
         Arrays.fill(this.emptinessMapCache, null);
+        Arrays.fill(this.fluidCapCache, null);
         if (this.isClientSide) {
             Arrays.fill(this.notifyUpdateCache, false);
         }

--- a/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarBlockEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarBlockEngine.java
@@ -88,7 +88,7 @@ public class ScalarBlockEngine extends PulsarEngine {
         final int currentLevel = this.getLightLevel(worldX, worldY, worldZ);
 
         final IBlockState state = this.getBlockState(worldX, worldY, worldZ);
-        final int info = LightInfo.of(state);
+        final int info = this.lightInfoAt(state, worldX, worldY, worldZ);
         final int emission = LightInfo.emission(info);
 
         // No "level unchanged" early-out (upstream): an equal level cannot
@@ -114,7 +114,7 @@ public class ScalarBlockEngine extends PulsarEngine {
     @Override
     protected int calculateLightValue(final int worldX, final int worldY, final int worldZ, final int expect) {
         return this.calculateLightValueWithInfo(worldX, worldY, worldZ, expect,
-                LightInfo.of(this.getBlockState(worldX, worldY, worldZ)));
+                this.lightInfoAt(this.getBlockState(worldX, worldY, worldZ), worldX, worldY, worldZ));
     }
 
     private int calculateLightValueWithInfo(final int worldX, final int worldY, final int worldZ, final int expect, final int info) {
@@ -201,16 +201,16 @@ public class ScalarBlockEngine extends PulsarEngine {
                 final int ly = index >>> 8;
                 final int lz = (index >>> 4) & 15;
 
+                final int worldX = offX | lx;
+                final int worldY = offY | ly;
+                final int worldZ = offZ | lz;
+
                 final IBlockState state = this.getBlockStateFast(sectionIdx, lx, ly, lz);
-                final int info = LightInfo.of(state);
+                final int info = this.lightInfoAt(state, worldX, worldY, worldZ);
                 final int emission = LightInfo.emission(info);
                 if (emission <= 0) {
                     continue;
                 }
-
-                final int worldX = offX | lx;
-                final int worldY = offY | ly;
-                final int worldZ = offZ | lz;
 
                 final int currentLevel = this.getLightLevel(worldX, worldY, worldZ);
                 if (emission <= currentLevel) {
@@ -261,7 +261,7 @@ public class ScalarBlockEngine extends PulsarEngine {
             if (hasSidedTransparent) {
                 final int srcIdx = (posX >> 4) + 5 * (posZ >> 4) + (5 * 5) * (posY >> 4) + sectionOffset;
                 final IBlockState srcState = this.getBlockStateFast(srcIdx, posX & 15, posY & 15, posZ & 15);
-                srcBlockedFaces = LightInfo.faceBits(LightInfo.of(srcState));
+                srcBlockedFaces = LightInfo.faceBits(this.lightInfoAt(srcState, posX, posY, posZ));
             }
 
             if ((queueValue & FLAG_RECHECK_LEVEL) != 0L) {
@@ -296,7 +296,7 @@ public class ScalarBlockEngine extends PulsarEngine {
                 }
 
                 final IBlockState destState = this.getBlockStateFast(sectionIndex, offX & 15, offY & 15, offZ & 15);
-                final int destInfo = LightInfo.of(destState);
+                final int destInfo = this.lightInfoAt(destState, offX, offY, offZ);
                 final int absorption = LightInfo.absorption(destInfo, destState, propagate.oppositeOrdinal);
 
                 final int targetLevel = propagatedLevel - absorption;
@@ -356,7 +356,7 @@ public class ScalarBlockEngine extends PulsarEngine {
             if (hasSidedTransparent) {
                 final int srcIdx = (posX >> 4) + 5 * (posZ >> 4) + (5 * 5) * (posY >> 4) + sectionOffset;
                 final IBlockState srcState = this.getBlockStateFast(srcIdx, posX & 15, posY & 15, posZ & 15);
-                srcBlockedFaces = LightInfo.faceBits(LightInfo.of(srcState));
+                srcBlockedFaces = LightInfo.faceBits(this.lightInfoAt(srcState, posX, posY, posZ));
             }
 
             for (final AxisDirection propagate : checkDirections) {
@@ -379,7 +379,7 @@ public class ScalarBlockEngine extends PulsarEngine {
                 }
 
                 final IBlockState state = this.getBlockStateFast(sectionIndex, offX & 15, offY & 15, offZ & 15);
-                final int info = LightInfo.of(state);
+                final int info = this.lightInfoAt(state, offX, offY, offZ);
                 final int absorption = LightInfo.absorption(info, state, propagate.oppositeOrdinal);
 
                 final int targetLevel = propagatedLevel - absorption;

--- a/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarSkyEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarSkyEngine.java
@@ -217,13 +217,13 @@ public class ScalarSkyEngine extends PulsarEngine {
 
         int currentSky = extrudedLevel;
 
-        int aboveInfo = LightInfo.of(this.getBlockState(worldX, startY + 1, worldZ));
+        int aboveInfo = this.lightInfoAt(this.getBlockState(worldX, startY + 1, worldZ), worldX, startY + 1, worldZ);
 
         for (; startY >= (this.minLightSection << 4); --startY) {
             if ((startY & 15) == 15) {
                 this.checkNullSection(worldX >> 4, startY >> 4, worldZ >> 4, extrudeInitialised);
             }
-            final int currentInfo = LightInfo.of(this.getBlockState(worldX, startY, worldZ));
+            final int currentInfo = this.lightInfoAt(this.getBlockState(worldX, startY, worldZ), worldX, startY, worldZ);
 
             // Check if light can pass DOWN through the above block
             final int aboveOpacity = LightInfo.opacity(aboveInfo);
@@ -463,7 +463,7 @@ public class ScalarSkyEngine extends PulsarEngine {
         }
 
         final int sectionOffset = this.chunkSectionIndexOffset;
-        final int info = LightInfo.of(this.getBlockState(worldX, worldY, worldZ));
+        final int info = this.lightInfoAt(this.getBlockState(worldX, worldY, worldZ), worldX, worldY, worldZ);
         final int rawOpacity = LightInfo.opacity(info);
         final boolean sidedTransparent = rawOpacity > 1 && (info & LightInfo.REGISTRY) != 0;
         final int faceBits = LightInfo.faceBits(info);
@@ -611,7 +611,7 @@ public class ScalarSkyEngine extends PulsarEngine {
             if (hasSidedTransparent) {
                 final int srcIdx = (posX >> 4) + 5 * (posZ >> 4) + (5 * 5) * (posY >> 4) + sectionOffset;
                 final IBlockState srcState = this.getBlockStateFast(srcIdx, posX & 15, posY & 15, posZ & 15);
-                srcBlockedFaces = LightInfo.faceBits(LightInfo.of(srcState));
+                srcBlockedFaces = LightInfo.faceBits(this.lightInfoAt(srcState, posX, posY, posZ));
             }
 
             if ((queueValue & FLAG_RECHECK_LEVEL) != 0L) {
@@ -646,7 +646,7 @@ public class ScalarSkyEngine extends PulsarEngine {
                 }
 
                 final IBlockState destState = this.getBlockStateFast(sectionIndex, offX & 15, offY & 15, offZ & 15);
-                final int destInfo = LightInfo.of(destState);
+                final int destInfo = this.lightInfoAt(destState, offX, offY, offZ);
                 final int absorption = LightInfo.absorption(destInfo, destState, propagate.oppositeOrdinal);
 
                 final int targetLevel = propagatedLevel - absorption;
@@ -706,7 +706,7 @@ public class ScalarSkyEngine extends PulsarEngine {
             if (hasSidedTransparent) {
                 final int srcIdx = (posX >> 4) + 5 * (posZ >> 4) + (5 * 5) * (posY >> 4) + sectionOffset;
                 final IBlockState srcState = this.getBlockStateFast(srcIdx, posX & 15, posY & 15, posZ & 15);
-                srcBlockedFaces = LightInfo.faceBits(LightInfo.of(srcState));
+                srcBlockedFaces = LightInfo.faceBits(this.lightInfoAt(srcState, posX, posY, posZ));
             }
 
             for (final AxisDirection propagate : checkDirections) {
@@ -735,7 +735,7 @@ public class ScalarSkyEngine extends PulsarEngine {
                 // decreases it, so sources stay intact.
 
                 final IBlockState state = this.getBlockStateFast(sectionIndex, offX & 15, offY & 15, offZ & 15);
-                final int info = LightInfo.of(state);
+                final int info = this.lightInfoAt(state, offX, offY, offZ);
                 final int absorption = LightInfo.absorption(info, state, propagate.oppositeOrdinal);
 
                 final int targetLevel = propagatedLevel - absorption;

--- a/src/main/java/com/sumirelabs/pulsar/mixin/MixinChunk.java
+++ b/src/main/java/com/sumirelabs/pulsar/mixin/MixinChunk.java
@@ -5,6 +5,7 @@ package com.sumirelabs.pulsar.mixin;
 // pulsar$ prefix below avoids any name collision.
 
 import com.sumirelabs.pulsar.api.ExtendedChunk;
+import com.sumirelabs.pulsar.compat.FluidLightBridge;
 import com.sumirelabs.pulsar.light.ChunkLightHelper;
 import com.sumirelabs.pulsar.light.PulsarChunk;
 import com.sumirelabs.pulsar.light.SWMRNibbleArray;
@@ -313,7 +314,13 @@ public abstract class MixinChunk implements PulsarChunk, ExtendedChunk {
      */
     @Unique
     private int pulsar$opacityAt(final int x, final int y, final int z) {
-        return this.getBlockState(x, y, z).getLightOpacity();
+        final int opacity = this.getBlockState(x, y, z).getLightOpacity();
+        if (!FluidLightBridge.LOADED) {
+            return opacity;
+        }
+        // Fluidlogged API: a stored fluid contributes max(block, fluid)
+        // opacity, so fluidlogged blocks count for the heightmap too.
+        return FluidLightBridge.maxOpacityAt((Chunk) (Object) this, opacity, x, y, z);
     }
 
     @Unique


### PR DESCRIPTION
Fluidlogged API keeps the logged fluid in a per-chunk capability and patches the VANILLA engine to light with max(block, fluid) - invisible to Pulsar's per-state LightInfo cache, so water-logged blocks did not attenuate and lava-logged blocks did not glow.
New FluidLightBridge (soft dependency, Alfheim-style static-final gate, zero overhead when absent) merges the fluid's opacity/emission into the packed LightInfo bits as a uniform absorber. Wired through one seam per layer: PulsarEngine.lightInfoAt() backed by a fluid-capability cache parallel to the 5x5 chunk cache (resolved once per task, not per BFS visit); all BFS/scan/sky-walk reads in both engines; and MixinChunk's pulsar$opacityAt for the heightmap paths.
No trigger work needed: FluidloggedUtils.setFluidState already calls chunk.relightBlock + world.checkLight, which Pulsar's hooks turn into scheduled updates.