### PR TITLE
Defer `performLightDecrease` after checking all edges

### DIFF
--- a/src/main/java/com/sumirelabs/pulsar/light/engine/PulsarEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/PulsarEngine.java
@@ -361,8 +361,8 @@ public abstract class PulsarEngine extends LightEngineCache {
             final IntIterator it = sections.iterator();
             while (it.hasNext()) {
                 this.checkChunkEdge(chunkX, it.nextInt(), chunkZ);
-                this.performLightDecrease();
             }
+            this.performLightDecrease();
             this.updateVisible();
         } finally {
             this.destroyCaches();


### PR DESCRIPTION
Haven't checked concrete numbers, but this should alleviate a lot of the workload with no semantic change.