### PR TITLE
fix(light): sync live section data before chunk packets

### DIFF
--- a/src/main/java/com/sumirelabs/pulsar/light/engine/LightEngineCache.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/LightEngineCache.java
@@ -161,6 +161,25 @@ abstract class LightEngineCache {
                 chunkX + 5 * chunkZ + (5 * 5) * chunkY + this.chunkSectionIndexOffset];
     }
 
+    protected final boolean isVanillaStorageSection(final int cacheIndex) {
+        final int sectionY = cacheIndex / 25 - this.chunkOffsetY;
+        return sectionY >= this.minSection && sectionY <= this.maxSection;
+    }
+
+    protected final ExtendedBlockStorage getLiveChunkSection(final int cacheIndex) {
+        final int localChunkIndex = cacheIndex % 25;
+        final Chunk chunk = this.chunkCache[localChunkIndex];
+        if (chunk == null) {
+            return null;
+        }
+        final int localSectionY = cacheIndex / 25;
+        final int sectionY = localSectionY - this.chunkOffsetY;
+        final int storageIndex = this.heightContext.getStorageIndex(sectionY);
+        final ExtendedBlockStorage[] sections = chunk.getBlockStorageArray();
+        return storageIndex >= 0 && storageIndex < sections.length
+                ? sections[storageIndex] : null;
+    }
+
     protected final void setChunkSectionInCache(final int chunkX, final int chunkY, final int chunkZ,
                                                 final ExtendedBlockStorage section) {
         this.sectionCache[

--- a/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarBlockEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarBlockEngine.java
@@ -449,12 +449,13 @@ public class ScalarBlockEngine extends PulsarEngine {
 
     @Override
     protected void onNibbleVisible(final int cacheIndex, final SWMRNibbleArray nibble) {
-        if (nibble == null) return;
-        final int cy = cacheIndex / 25;
-        final int sectionY = cy - this.chunkOffsetY;
-        if (sectionY < this.minSection || sectionY > this.maxSection) return;
-        final ExtendedBlockStorage section = this.sectionCache[cacheIndex];
-        if (section == null) return;
+        if (nibble == null || !this.isVanillaStorageSection(cacheIndex)) {
+            return;
+        }
+        final ExtendedBlockStorage section = this.getLiveChunkSection(cacheIndex);
+        if (section == null) {
+            return;
+        }
         final byte[] srcData = nibble.getVisibleData();
         if (srcData == null) return;
         final NibbleArray vanilla = section.getBlockLight();

--- a/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarSkyEngine.java
+++ b/src/main/java/com/sumirelabs/pulsar/light/engine/ScalarSkyEngine.java
@@ -469,12 +469,13 @@ public class ScalarSkyEngine extends PulsarEngine {
 
     @Override
     protected void onNibbleVisible(final int cacheIndex, final SWMRNibbleArray nibble) {
-        if (nibble == null) return;
-        final int cy = cacheIndex / 25;
-        final int sectionY = cy - this.chunkOffsetY;
-        if (sectionY < this.minSection || sectionY > this.maxSection) return;
-        final ExtendedBlockStorage section = this.sectionCache[cacheIndex];
-        if (section == null) return;
+        if (nibble == null || !this.isVanillaStorageSection(cacheIndex)) {
+            return;
+        }
+        final ExtendedBlockStorage section = this.getLiveChunkSection(cacheIndex);
+        if (section == null) {
+            return;
+        }
         final byte[] srcData = nibble.getVisibleData();
         if (srcData == null) return;
         final NibbleArray vanilla = section.getSkyLight();

--- a/src/main/java/com/sumirelabs/pulsar/mixin/MixinSPacketChunkData.java
+++ b/src/main/java/com/sumirelabs/pulsar/mixin/MixinSPacketChunkData.java
@@ -1,19 +1,38 @@
 package com.sumirelabs.pulsar.mixin;
 
 import com.sumirelabs.pulsar.light.ChunkPacketLight;
+import com.sumirelabs.pulsar.light.PulsarChunk;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketChunkData;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * Keeps non-trivial light in block-empty sections of full chunk packets.
  */
 @Mixin(SPacketChunkData.class)
 public abstract class MixinSPacketChunkData {
+
+    // Chunk packets serialize vanilla EBS arrays, so publish visible Pulsar light first.
+    @Inject(
+            method = "<init>(Lnet/minecraft/world/chunk/Chunk;I)V",
+            at = @At("HEAD"),
+            require = 0)
+    private static void pulsar$syncVisibleLightBeforePacket(final Chunk chunk,
+                                                            final int changedSectionFilter,
+                                                            final CallbackInfo ci) {
+        if (chunk instanceof PulsarChunk) {
+            final PulsarChunk pulsarChunk = (PulsarChunk) chunk;
+            if (pulsarChunk.pulsar$isLightReady()) {
+                pulsarChunk.pulsar$syncLightToVanilla();
+            }
+        }
+    }
 
     @Redirect(
             method = "extractChunkData(Lnet/minecraft/network/PacketBuffer;Lnet/minecraft/world/chunk/Chunk;ZI)I",


### PR DESCRIPTION
This fixes black spots that could appear when chunk sections were created or replaced after the lighting engine had already cached them. Pulsar could update an old section reference while the chunk packet used the current section with empty light data.
The change now updates the live chunk section and syncs the latest visible light data before the chunk packet is created. I tested it in-game and could no longer reproduce the black spots.
<img width="2560" height="1494" alt="2026-08-30_11 33 25" src="https://github.com/user-attachments/assets/e0674a47-8e39-47f0-b55b-5dd19fb3e5ac" />
<img width="2560" height="1494" alt="2026-08-30_11 35 56" src="https://github.com/user-attachments/assets/cf557913-da43-4ef7-8e42-09aafc852f1e" />
